### PR TITLE
 Cambia `string` y `substring` por `texto` y `subtexto`

### DIFF
--- a/1-stringtitis.md
+++ b/1-stringtitis.md
@@ -4,3 +4,15 @@
 ## Descripción
 
 Escribe una función que tome un `texto` y un `subtexto`y devuelva `true` si el `texto` contiene el `subtexto` y `false` en caso contrario.
+
+Ejemplo:
+
+```js
+
+hasText('Laboratoria', 'oratoria');
+// true
+
+hasText('Equipo', 'yo');
+// false
+
+```


### PR DESCRIPTION
Al existir un método de `String` llamado `substring`
(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring)
me parece que pueda causar confusión usarlo para hacer
referencia a otra cosa en el mismo contexto de un ejercicio
de JavaScript.

Incluso alguna estudiante podría googlear ese término y
confundirse.

Cambiándolo por `Texto` y `Subtexto` creo que podemos obviar
esa confusión.

También agrega un ejemplo