### PR TITLE
Actualiza URLs de proyectos (rama main en vez de master)

### DIFF
--- a/interviewer-guide/projects.md
+++ b/interviewer-guide/projects.md
@@ -2,7 +2,7 @@
 
 Los proyectos que han desarrollado hasta ahora han sido los siguientes:
 
-## [Cifrado César](https://github.com/Laboratoria/bootcamp/blob/master/projects/01-cipher/README.md)
+## [Cifrado César](https://github.com/Laboratoria/bootcamp/tree/main/projects/01-cipher/)
 
 Una aplicación con interfaz realizada en HTML, CSS y vanilla JS, donde la idea
 es tener un campo de texto para cifrar y otro para descifrar un mensaje en base
@@ -17,7 +17,7 @@ a un número. Ese número se utiliza para encriptar/desencriptar el mensaje en l
 * Git & Github
 * Unit Testing
 
-## [Data Lovers](https://github.com/Laboratoria/bootcamp/blob/master/projects/02-data-lovers/README.md)
+## [Data Lovers](https://github.com/Laboratoria/bootcamp/tree/main/projects/02-data-lovers/)
 
 Una aplicación con interfaz hecha en HTML, CSS y vanilla JS también, donde la
 idea es consumir una lista de datos (estáticos) sobre algún tema/personajes y
@@ -30,7 +30,7 @@ crear un sitio que muestre datos y estadísticas sobre esos personajes.
 - Manejo de estructuras de datos con JS
 - Consumo de API REST
 
-## [Red Social](https://github.com/Laboratoria/bootcamp/blob/master/projects/03-social-network/README.md)
+## [Red Social](https://github.com/Laboratoria/bootcamp/tree/main/projects/03-social-network/)
 
 ¡Es el primer contacto con un servidor desde el navegador! En este proyecto
 crearon una red social utilizando Firebase, con una pantalla de inicio de sesión
@@ -44,7 +44,7 @@ crearon una red social utilizando Firebase, con una pantalla de inicio de sesió
 - Asincronía con JS
 - UI Testing
 
-## [MD Links](https://github.com/Laboratoria/bootcamp/blob/master/projects/04-md-links/README.md)
+## [MD Links](https://github.com/Laboratoria/bootcamp/tree/main/projects/04-md-links/)
 
 El objetivo de este proyecto era la creación de una biblioteca que se ejecutara
 a través de la terminal (CLI). La librería se encargaba de recibir la ruta de
@@ -59,7 +59,7 @@ mensaje de salida.
 - CLI
 - Unit Testing Avanzado
 
-## [Burguer Queen](https://github.com/Laboratoria/bootcamp/blob/master/projects/04-burger-queen/README.md)
+## [Burguer Queen](https://github.com/Laboratoria/bootcamp/tree/main/projects/04-burger-queen/)
 
 El enfoque de este proyecto es aplicar un framework/librería
 (React / Angular / Vue) por primera vez, aliándose con los conocimientos previos


### PR DESCRIPTION
La rama `master` se renombró a `main` hace ya unos meses. Por otro lado, también cambia la rutas para que apunten a las carpetas de proyecto en vez de directamente a los readmes (quizás así sea más visible también el boilerplate y no solo el enunciado :thinking:).